### PR TITLE
add support for mongodb aggregate pipelines

### DIFF
--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
@@ -177,6 +177,12 @@ public class ConnectorListener {
                         (Map<String, Object>) msg.params.get("properties"), (Map<String, Object>) msg.params.get("qual"),
                         (Map<String, Object>) msg.params.get("options"));
                     break;
+                case "aggregate":
+                    result = storageManager.aggregate((String) msg.params.get("storageName"),
+                            (Map<String, Object>) msg.params.get("storageManagerReference"),
+                            (List<Map<String, Object>>) msg.params.get("pipeline"),
+                            (Map<String, Object>) msg.params.get("options"));
+                    break;
                 case "selectOne":
                     result = storageManager.selectOne((String) msg.params.get("storageName"),
                         (Map<String, Object>) msg.params.get("storageManagerReference"),

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/InstanceConfigUtils.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/InstanceConfigUtils.java
@@ -144,7 +144,7 @@ public class InstanceConfigUtils {
         }
         return localServerConfigProps.getProperty("defaultDatabase");
     }
-    
+
     /**
      * Helper method used to get the TCP Probe Port if specified in the server.config
      *

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/RequestProcessingVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/RequestProcessingVerticle.java
@@ -63,11 +63,13 @@ public class RequestProcessingVerticle extends AbstractVerticle implements Sessi
                 SockJSHandlerOptions options = new SockJSHandlerOptions().setMaxBytesStreaming(1024 * 1024);
                 SockJSHandler sockJSHandler = SockJSHandler.create(getVertx(), options);
                 router.route("/wsock/*").subRouter(sockJSHandler.socketHandler(this::handleWebsocketRequest));
+                log.debug("creating http server at port {}", config.obtainPrimaryPort());
                 vertx.createHttpServer().requestHandler(router).listen(config.obtainPrimaryPort(), http -> {
                     if (http.succeeded()) {
                         startPromise.complete();
-                        log.info("HTTP server started on port " + config.obtainPrimaryPort());
+                        log.info("HTTP server successfully started on port " + config.obtainPrimaryPort());
                     } else {
+                        log.debug("create http server failed with {}", http.cause().getMessage());
                         startPromise.fail(http.cause());
                     }
                 });

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/RequestProcessingVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/RequestProcessingVerticle.java
@@ -23,11 +23,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * All rights reserved.
  */
+@Getter
 @Slf4j
 public class RequestProcessingVerticle extends AbstractVerticle implements Sessionizer {
-    @Getter
     SessionStore sessionStore;
-    @Getter
     SessionCreator sessionCreator;
     static VantiqStorageManager storageManager;
 
@@ -75,9 +74,7 @@ public class RequestProcessingVerticle extends AbstractVerticle implements Sessi
                 });
             })
         ).subscribe(
-            () -> {
-                log.debug("Service connector started");
-            },
+            () -> log.debug("Service connector started"),
             err -> {
                 log.error("Error starting service connector", err);
                 startPromise.fail(err);
@@ -87,6 +84,7 @@ public class RequestProcessingVerticle extends AbstractVerticle implements Sessi
 
     public void handleWebsocketRequest(SockJSSocket socket) {
         log.debug("new websocket connection");
+        @SuppressWarnings("unused")
         ConnectorListener listener = new ConnectorListener(socket, storageManager, this);
     }
 }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
@@ -55,4 +55,7 @@ public interface VantiqStorageManager {
                                          Map<String, Object> options);
     
     Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual);
+    
+    Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference,
+                                            List<Map<String, Object>> pipeline, Map<String, Object> options);
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
@@ -72,4 +72,9 @@ public class NoopStorageManager implements VantiqStorageManager {
     public Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual) {
         return Single.just(0);
     }
+
+    @Override
+    public Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> pipeline, Map<String, Object> options) {
+        return Flowable.empty();
+    }
 }

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Storage manager for MongoDB Atlas. This storage manager is designed to work with MongoDB Atlas clusters. It
@@ -545,4 +546,13 @@ public class AtlasStorageMgr implements VantiqStorageManager {
             Math.toIntExact(dr.getDeletedCount())
         );
     }
+
+    @Override
+    public Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> pipeline, Map<String, Object> options) {
+        return this.collectionFromStorageName(storageName, collection -> {
+            List<Document> mongoPipeline = pipeline.stream().map(Document::new).collect(Collectors.toList());
+            return collection.aggregate(mongoPipeline).maxTime(QUERY_TIMEOUT, QUERY_TIMEOUT_TIMEUNIT);
+        }).map(AtlasStorageMgr::externalizeId);
+    }
+
 }

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 
 /**
  * Storage manager for MongoDB Atlas. This storage manager is designed to work with MongoDB Atlas clusters. It
- * supports all of the storage manager API calls.
+ * supports all the storage manager API calls.
  * <p>
  * Copyright (c) 2023 Vantiq, Inc.
  * <p>
@@ -301,9 +301,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
             return Flowable.empty();
         }
         List<Document> docs = new ArrayList<>();
-        values.forEach(value -> {
-            docs.add(new Document(value).append("_id", new ObjectId()));
-        });
+        values.forEach(value -> docs.add(new Document(value).append("_id", new ObjectId())));
 
         return collectionFromStorageName(storageName, collection -> {
             InsertManyOptions insertOpts = new InsertManyOptions().ordered(false);
@@ -498,9 +496,10 @@ public class AtlasStorageMgr implements VantiqStorageManager {
             return clientObs.map(client -> client.getDatabase(databaseName)).cache();
         });
         AtomicLong start = new AtomicLong();
-        return sessionObs.flatMapPublisher(cmdFunction::apply).doOnSubscribe(s -> {
-            start.set(System.nanoTime());
-        }).observeOn(rxScheduler == null ? Schedulers.trampoline() : rxScheduler).doOnComplete(() -> {
+        return sessionObs.flatMapPublisher(cmdFunction::apply)
+                .doOnSubscribe(s ->start.set(System.nanoTime()))
+                .observeOn(rxScheduler == null ? Schedulers.trampoline() : rxScheduler)
+                .doOnComplete(() -> {
             long end = System.nanoTime();
             long duration = end - start.get();
             log.debug("Atlas round trip time: {} ms", duration / 1000000);


### PR DESCRIPTION
Pipelines are supported in the vantiq server 1.37 via the aggregate op

Fixes #6 