### PR TITLE
add support for transactions in MongoDB Atlas

### DIFF
--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
@@ -234,21 +234,18 @@ public class ConnectorListener {
                 case "startTransaction":
                     result = storageManager.startTransaction(
                         (String)msg.params.get("vantiqTransactionId"),
-                        (Map<String, Object>) msg.params.get("storageManagerReference"),
                         (Map<String, Object>) msg.params.get("options")
                     ).toFlowable();
                     break;
                 case "commitTransaction":
                     result = storageManager.commitTransaction(
                             (String)msg.params.get("vantiqTransactionId"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
                             (Map<String, Object>) msg.params.get("options")
                     ).toFlowable();
                     break;
                 case "abortTransaction":
                     result = storageManager.abortTransaction(
                             (String)msg.params.get("vantiqTransactionId"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
                             (Map<String, Object>) msg.params.get("options")
                     ).toFlowable();
                     break;

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
@@ -245,6 +245,13 @@ public class ConnectorListener {
                             (Map<String, Object>) msg.params.get("options")
                     ).toFlowable();
                     break;
+                case "abortTransaction":
+                    result = storageManager.abortTransaction(
+                            (String)msg.params.get("vantiqTransactionId"),
+                            (Map<String, Object>) msg.params.get("storageManagerReference"),
+                            (Map<String, Object>) msg.params.get("options")
+                    ).toFlowable();
+                    break;
                 default:
                     result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +
                         msg.procName));

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/ConnectorListener.java
@@ -157,18 +157,21 @@ public class ConnectorListener {
                 case "update":
                     result = storageManager.update((String) msg.params.get("storageName"),
                         (Map<String, Object>) msg.params.get("storageManagerReference"),
-                        (Map<String, Object>) msg.params.get("values"), (Map<String, Object>) msg.params.get("qual"))
+                        (Map<String, Object>) msg.params.get("values"), (Map<String, Object>) msg.params.get("qual"),
+                        (Map<String, Object>) msg.params.get("options"))
                             .toFlowable();
                     break;
                 case "insertMany":
                     result = storageManager.insertMany((String) msg.params.get("storageName"),
                         (Map<String, Object>) msg.params.get("storageManagerReference"),
-                        (List<Map<String, Object>>) msg.params.get("values"));
+                        (List<Map<String, Object>>) msg.params.get("values"),
+                        (Map<String, Object>)msg.params.get("options"));
                     break;
                 case "insert":
                     result = storageManager.insert((String) msg.params.get("storageName"),
                         (Map<String, Object>) msg.params.get("storageManagerReference"),
-                        (Map<String, Object>) msg.params.get("values")).toFlowable();
+                        (Map<String, Object>) msg.params.get("values"),
+                        (Map<String, Object>) msg.params.get("options")).toFlowable();
                     break;
                 case "count":
                     result = storageManager.count((String) msg.params.get("storageName"),
@@ -198,7 +201,7 @@ public class ConnectorListener {
                 case "delete":
                     result = storageManager.delete((String) msg.params.get("storageName"),
                         (Map<String, Object>) msg.params.get("storageManagerReference"),
-                        (Map<String, Object>) msg.params.get("qual"))
+                        (Map<String, Object>) msg.params.get("qual"), (Map<String, Object>) msg.params.get("options"))
                             .toFlowable();
                     break;
                 case "getTypeRestrictions":
@@ -227,6 +230,20 @@ public class ConnectorListener {
                                 (Map<String, Object>) msg.params.get("options")
                         ).toFlowable();
                     }
+                    break;
+                case "startTransaction":
+                    result = storageManager.startTransaction(
+                        (String)msg.params.get("vantiqTransactionId"),
+                        (Map<String, Object>) msg.params.get("storageManagerReference"),
+                        (Map<String, Object>) msg.params.get("options")
+                    ).toFlowable();
+                    break;
+                case "commitTransaction":
+                    result = storageManager.commitTransaction(
+                            (String)msg.params.get("vantiqTransactionId"),
+                            (Map<String, Object>) msg.params.get("storageManagerReference"),
+                            (Map<String, Object>) msg.params.get("options")
+                    ).toFlowable();
                     break;
                 default:
                     result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
@@ -60,12 +60,9 @@ public interface VantiqStorageManager {
     Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference,
                                             List<Map<String, Object>> pipeline, Map<String, Object> options);
 
-    Completable startTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                                    Map<String, Object> options);
+    Completable startTransaction(String vantiqTransactionId, Map<String, Object> options);
 
-    Completable commitTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                                 Map<String, Object> options);
+    Completable commitTransaction(String vantiqTransactionId, Map<String, Object> options);
 
-    Completable abortTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                                  Map<String, Object> options);
+    Completable abortTransaction(String vantiqTransactionId, Map<String, Object> options);
 }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
@@ -36,13 +36,13 @@ public interface VantiqStorageManager {
     Completable typeDefinitionDeleted(Map<String, Object> type, Map<String, Object> options);
 
     Single<Map<String, Object>> insert(String storageName, Map<String, Object> storageManagerReference,
-                                         Map<String, Object> values);
+                                         Map<String, Object> values, Map<String, Object> options);
     
     Flowable<Map<String, Object>> insertMany(String storageName, Map<String, Object> storageManagerReference,
-                                             List<Map<String, Object>> values);
+                                             List<Map<String, Object>> values, Map<String, Object> options);
     
     Maybe<Map<String, Object>> update(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values,
-                                         Map<String, Object> qual);
+                                         Map<String, Object> qual, Map<String, Object> options);
     
     Single<Integer> count(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual,
                             Map<String, Object> options);
@@ -54,8 +54,18 @@ public interface VantiqStorageManager {
                                          Map<String, Object> properties, Map<String, Object> qual,
                                          Map<String, Object> options);
     
-    Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual);
+    Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual,
+                           Map<String, Object> options);
     
     Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference,
                                             List<Map<String, Object>> pipeline, Map<String, Object> options);
+
+    Completable startTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
+                                    Map<String, Object> options);
+
+    Completable commitTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
+                                 Map<String, Object> options);
+
+    Completable abortTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
+                                  Map<String, Object> options);
 }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/util/CacheIfNotEmptyOrError.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/util/CacheIfNotEmptyOrError.java
@@ -1,0 +1,46 @@
+package io.vantiq.util;
+/*
+ * <p>
+ * Copyright (c) 2023 Vantiq, Inc.
+ * <p>
+ * All rights reserved.
+ */
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableTransformer;
+import lombok.val;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CacheIfNotEmptyOrError<T> implements FlowableTransformer<T, T> {
+    private final AtomicReference<Flowable<T>> cachedRef = new AtomicReference<>();
+
+    @NonNull
+    @Override
+    public Flowable<T> apply(@NonNull Flowable<T> source) {
+        return Flowable.defer(() -> {
+            // Spin loop until we get a definitive result
+            for (;;) {
+                // See if we already have a cached observable, if so, use it
+                val cached = cachedRef.get();
+                if (cached != null) {
+                    return cached;
+                }
+
+                // Construct a cached observable that clears the cache if it is empty or generates an error
+                val newObs = source.cache()
+                        .switchIfEmpty(Flowable.<T>empty().doOnComplete(() -> cachedRef.set(null)))
+                        .onErrorResumeNext( ex -> {
+                            cachedRef.set(null);
+                            return Flowable.error(ex);
+                        });
+
+                // Make sure no one beat us to this
+                if (cachedRef.compareAndSet(null, newObs)) {
+                    return newObs;
+                }
+            }
+        });
+    }
+}

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/util/VertxWideData.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/util/VertxWideData.java
@@ -1,0 +1,140 @@
+package io.vantiq.util;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.Weigher;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Shareable;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Atomic, shareable object reference.<br/>
+ *
+ * Created by sfitts on 9/5/2015.
+ */
+public class VertxWideData<T> extends AtomicReference<T> implements Shareable {
+    public static final String GLOBALS_MAP_NAME = "io.vantiq.vertx.globalData";
+
+    VertxWideData(T ref) { //noinspection GroovyAssignabilityCheck
+        super(ref);
+    }
+
+    /**
+     * Get a concurrent map which will be shared across the given Vertx instance.
+     *
+     * @param vertx current vertx
+     * @param mapName name of the map
+     * @param <V> type of map values
+     * @return the vertx wide map
+     */
+    @SuppressWarnings("unused")
+    public static <V> ConcurrentMap<String, V> getVertxWideMap(Vertx vertx, String mapName) {
+        LocalMap<String, VertxWideData<ConcurrentMap<String, V>>> globalsMap = vertx.sharedData().getLocalMap(GLOBALS_MAP_NAME);
+        VertxWideData<ConcurrentMap<String, V>> sharedMapGlobal = new VertxWideData<>(new ConcurrentHashMap<>());
+        if (globalsMap.putIfAbsent(mapName, sharedMapGlobal) != null) {
+            sharedMapGlobal = globalsMap.get(mapName);
+        }
+        return sharedMapGlobal.get();
+    }
+
+    /**
+     * Get a Guava Cache instance which will be shared across the given Vert.x instance.
+     *
+     * @param vertx current vertx
+     * @param mapName name for the cache we find or create
+     * @param cacheSpec guava cache specification
+     * @param ticker time source
+     * @param removalListener listener for removal events
+     * @param weigher weigher for cache entries
+     * @return the vertx wide cache either newly created or found in vertx shared data
+     */
+    public static <K, V> Cache<K, V> getVertxWideCache(Vertx vertx, String mapName, String cacheSpec, Ticker ticker,
+                                                RemovalListener<K, V> removalListener, Weigher<K, V> weigher) {
+        return getVertxWideInstance(vertx, mapName, () -> {
+            @SuppressWarnings("unchecked")
+            CacheBuilder<K,V> builder = (CacheBuilder<K, V>) CacheBuilder.from(cacheSpec);
+            if (ticker != null) {
+                builder.ticker(ticker);
+            }
+            if (removalListener != null) {
+                builder.removalListener(removalListener);
+            }
+            if (weigher != null) {
+                builder.weigher(weigher);
+            }
+            return builder.build();
+        }); 
+    }
+
+    /**
+     * Return an object instance that is shared across the given Vert.x.  If the object does not yet exist, it will
+     * be obtained from the given supplier.  Otherwise, the shared instance will be returned.
+     *
+     * @param vertx current vertx
+     * @param instanceName name of the instance
+     * @param instanceSupplier supplier for the instance
+     * @return the vertx wide instance
+     */
+    public static <T> T getVertxWideInstance(Vertx vertx, String instanceName, Supplier<T> instanceSupplier) {
+        LocalMap<String, VertxWideData<T>> globalsMap = vertx.sharedData().getLocalMap(GLOBALS_MAP_NAME);
+        VertxWideData<T> instanceGlobal = globalsMap.computeIfAbsent(instanceName, key ->
+            new VertxWideData<>(instanceSupplier.get())
+        );
+        T instance = instanceGlobal.get();
+        Objects.requireNonNull(instance, "Supplier for vertx wide instance ${instanceName} returned null.");
+        return instance;
+    }
+
+    /**
+     * Return an object instance that is shared across the given Vert.x.  If the object does not yet exist, it will
+     * be obtained from the given supplier.  Otherwise, the shared instance will be returned.
+     *
+     * @param vertx current vertx
+     * @param instanceName the name of the instance
+     * @return the vertx wide instance
+     */
+    @SuppressWarnings("unused")
+    public static <T> T getVertxWideInstance(Vertx vertx, String instanceName) {
+        LocalMap<String, VertxWideData<T>> globalsMap = vertx.sharedData().getLocalMap(GLOBALS_MAP_NAME);
+        VertxWideData<T> instanceGlobal = globalsMap.get(instanceName);
+        return instanceGlobal != null ? instanceGlobal.get() : null;
+    }
+
+    /**
+     * Remove the named Vert.x wide instance.
+     *
+     * @param vertx current vertx
+     * @param dataName name of the instance
+     */
+    @SuppressWarnings("unused")
+    static void removeVertxWideData(Vertx vertx, String dataName) {
+        LocalMap<String, VertxWideData<?>> globalsMap = vertx.sharedData().getLocalMap(GLOBALS_MAP_NAME);
+        globalsMap.remove(dataName);
+    }
+
+    /**
+     * Remove all Vert.x wide instances for the given Vert.x.
+     *
+     * @param vertx current vertx
+     */
+    @SuppressWarnings("unused")
+    static void clearAll(Vertx vertx) {
+        LocalMap<String, VertxWideData<Object>> globalsMap = vertx.sharedData().getLocalMap(GLOBALS_MAP_NAME);
+        globalsMap.forEach( (name, data) -> {
+                Object obj = data.getAndSet(null);
+            if (obj instanceof Collection) {
+                ((Collection<?>)obj).clear();
+            }
+        });
+        globalsMap.clear();
+    }
+}

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/util/VertxWideData.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/util/VertxWideData.java
@@ -17,9 +17,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
- * Atomic, shareable object reference.<br/>
- *
- * Created by sfitts on 9/5/2015.
+ * Atomic, shareable object reference.
+ * <p/>
+ * Copyright (c) 2023 Vantiq, Inc.
+ * <p/>
+ * All rights reserved.
  */
 public class VertxWideData<T> extends AtomicReference<T> implements Shareable {
     public static final String GLOBALS_MAP_NAME = "io.vantiq.vertx.globalData";

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
@@ -79,17 +79,17 @@ public class NoopStorageManager implements VantiqStorageManager {
     }
 
     @Override
-    public Completable startTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+    public Completable startTransaction(String vantiqTransactionId, Map<String, Object> options) {
         return Completable.complete();
     }
 
     @Override
-    public Completable commitTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+    public Completable commitTransaction(String vantiqTransactionI, Map<String, Object> options) {
         return Completable.complete();
     }
 
     @Override
-    public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+    public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> options) {
         return Completable.complete();
     }
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
@@ -29,7 +29,8 @@ public class NoopStorageManager implements VantiqStorageManager {
     }
 
     @Override
-    public Single<Map<String, Object>> initializeTypeDefinition(Map<String, Object> proposedType, Map<String, Object> existingType) {
+    public Single<Map<String, Object>> initializeTypeDefinition(Map<String, Object> proposedType,
+                                                                Map<String, Object> existingType) {
         return Single.just(Collections.emptyMap());
     }
 
@@ -39,42 +40,53 @@ public class NoopStorageManager implements VantiqStorageManager {
     }
 
     @Override
-    public Single<Map<String, Object>> insert(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values, Map<String, Object> options) {
+    public Single<Map<String, Object>> insert(String storageName, Map<String, Object> storageManagerReference,
+                                              Map<String, Object> values, Map<String, Object> options) {
         return Single.just(Collections.emptyMap());
     }
 
     @Override
-    public Flowable<Map<String, Object>> insertMany(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> values, Map<String, Object> options) {
+    public Flowable<Map<String, Object>> insertMany(String storageName, Map<String, Object> storageManagerReference,
+                                                    List<Map<String, Object>> values, Map<String, Object> options) {
         return Flowable.empty();
     }
 
     @Override
-    public Maybe<Map<String, Object>> update(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values, Map<String, Object> qual, Map<String, Object> options) {
+    public Maybe<Map<String, Object>> update(String storageName, Map<String, Object> storageManagerReference,
+                                             Map<String, Object> values, Map<String, Object> qual,
+                                             Map<String, Object> options) {
         return Maybe.empty();
     }
 
     @Override
-    public Single<Integer> count(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual, Map<String, Object> options) {
+    public Single<Integer> count(String storageName, Map<String, Object> storageManagerReference,
+                                 Map<String, Object> qual, Map<String, Object> options) {
         return Single.just(0);
     }
 
     @Override
-    public Flowable<Map<String, Object>> select(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> properties, Map<String, Object> qual, Map<String, Object> options) {
+    public Flowable<Map<String, Object>> select(String storageName, Map<String, Object> storageManagerReference,
+                                                Map<String, Object> properties, Map<String, Object> qual,
+                                                Map<String, Object> options) {
         return Flowable.empty();
     }
 
     @Override
-    public Maybe<Map<String, Object>> selectOne(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> properties, Map<String, Object> qual, Map<String, Object> options) {
+    public Maybe<Map<String, Object>> selectOne(String storageName, Map<String, Object> storageManagerReference,
+                                                Map<String, Object> properties, Map<String, Object> qual,
+                                                Map<String, Object> options) {
         return Maybe.empty();
     }
 
     @Override
-    public Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual, Map<String, Object> options) {
+    public Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference,
+                                  Map<String, Object> qual, Map<String, Object> options) {
         return Single.just(0);
     }
 
     @Override
-    public Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> pipeline, Map<String, Object> options) {
+    public Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference,
+                                                   List<Map<String, Object>> pipeline, Map<String, Object> options) {
         return Flowable.empty();
     }
 

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/NoopStorageManager.java
@@ -39,17 +39,17 @@ public class NoopStorageManager implements VantiqStorageManager {
     }
 
     @Override
-    public Single<Map<String, Object>> insert(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values) {
+    public Single<Map<String, Object>> insert(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values, Map<String, Object> options) {
         return Single.just(Collections.emptyMap());
     }
 
     @Override
-    public Flowable<Map<String, Object>> insertMany(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> values) {
+    public Flowable<Map<String, Object>> insertMany(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> values, Map<String, Object> options) {
         return Flowable.empty();
     }
 
     @Override
-    public Maybe<Map<String, Object>> update(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values, Map<String, Object> qual) {
+    public Maybe<Map<String, Object>> update(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> values, Map<String, Object> qual, Map<String, Object> options) {
         return Maybe.empty();
     }
 
@@ -69,12 +69,27 @@ public class NoopStorageManager implements VantiqStorageManager {
     }
 
     @Override
-    public Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual) {
+    public Single<Integer> delete(String storageName, Map<String, Object> storageManagerReference, Map<String, Object> qual, Map<String, Object> options) {
         return Single.just(0);
     }
 
     @Override
     public Flowable<Map<String, Object>> aggregate(String storageName, Map<String, Object> storageManagerReference, List<Map<String, Object>> pipeline, Map<String, Object> options) {
         return Flowable.empty();
+    }
+
+    @Override
+    public Completable startTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+        return Completable.complete();
+    }
+
+    @Override
+    public Completable commitTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+        return Completable.complete();
+    }
+
+    @Override
+    public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference, Map<String, Object> options) {
+        return Completable.complete();
     }
 }

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -516,7 +516,8 @@ public class AtlasStorageMgr implements VantiqStorageManager {
      * @param cmdFunction function to execute with the session
      * @param <T> typically a Map, but generally the type of the observable expected
      */
-    <T> Flowable<T> usingSession(String databaseName, String xid, BiFunction<MongoDatabase, ClientSession, Publisher<T>> cmdFunction) {
+    <T> Flowable<T> usingSession(String databaseName, String xid, BiFunction<MongoDatabase, ClientSession,
+                                 Publisher<T>> cmdFunction) {
         Single<ImmutablePair<MongoDatabase, ClientSession>> sessionDbObs;
         sessionDbObs = sessions.asMap().computeIfAbsent(databaseName, name -> {
             Single<MongoClient> clientObs = connection.connect(config);
@@ -549,7 +550,8 @@ public class AtlasStorageMgr implements VantiqStorageManager {
     }
     
     <T> Flowable<T>
-    collectionFromStorageName(String storageName, Map<String, Object> options, BiFunction<MongoCollection<Document>, ClientSession, Publisher<T>> cmdFunction) {
+    collectionFromStorageName(String storageName, Map<String, Object> options, BiFunction<MongoCollection<Document>,
+                              ClientSession, Publisher<T>> cmdFunction) {
         String[] parts = storageName.split(":");
         String databaseName = parts.length < 2 ? config.obtainDefaultDatabase(): parts[0];
         String collectionName = parts.length < 2 ? parts[0]: parts[1];

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -588,8 +588,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
 
     @Override
     public Completable
-    startTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                     Map<String, Object> options) {
+    startTransaction(String vantiqTransactionId, Map<String, Object> options) {
         return Completable.fromAction(() ->
             transactions.asMap().computeIfAbsent(vantiqTransactionId, id -> {
                 Single<MongoClient> clientObs = connection.connect(config);
@@ -607,8 +606,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
     }
 
     @Override
-    public Completable commitTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                                         Map<String, Object> options) {
+    public Completable commitTransaction(String vantiqTransactionId, Map<String, Object> options) {
         Single<ClientSession> sessionObs = transactions.asMap().remove(vantiqTransactionId);
         if (sessionObs == null) {
             return Completable.error(new Exception("No transaction found for id " + vantiqTransactionId));
@@ -623,8 +621,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
     }
 
     @Override
-    public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> storageManagerReference,
-                                        Map<String, Object> options) {
+    public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> options) {
         Single<ClientSession> sessionObs = transactions.asMap().remove(vantiqTransactionId);
         if (sessionObs == null) {
             return Completable.error(new Exception("No transaction found for id " + vantiqTransactionId));

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -578,7 +578,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
                     // if we get here, startSession returned an empty publisher, should  never happen, but ...
                     Flowable.error(new Exception("Failed to create a session in which to start a transaction"))
                 ).firstOrError().doOnSuccess(session ->
-                    log.info("transactions started in session {} with number {}",
+                    log.debug("transactions started in session {} with number {}",
                             session.getServerSession().getIdentifier(),
                             session.getServerSession().getTransactionNumber())
                 );
@@ -595,7 +595,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
         }
         return sessionObs.flatMapPublisher(session ->
                 Flowable.fromPublisher(session.commitTransaction()).doOnComplete(() ->
-                    log.info("transaction {} committed", vantiqTransactionId)
+                    log.debug("transaction {} committed", vantiqTransactionId)
                 ).doOnError(t ->
                     log.warn("transaction {} failed to commit with error: {}", vantiqTransactionId, t.getMessage())
                 ).doOnComplete(session::close)

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -610,7 +610,7 @@ public class AtlasStorageMgr implements VantiqStorageManager {
             return Completable.error(new Exception("No transaction found for id " + vantiqTransactionId));
         }
         return sessionObs.flatMapPublisher(session ->
-                Flowable.fromPublisher(session.commitTransaction()).doOnComplete(session::close)
+                Flowable.fromPublisher(session.abortTransaction()).doOnComplete(session::close)
         ).ignoreElements();
     }
 

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/Connection.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/Connection.java
@@ -64,8 +64,13 @@ public class Connection {
             Properties properties = config.loadServerConfig();
             Properties secrets = config.loadServerSecrets();
             String connectionString = "mongodb+srv://" + secrets.getProperty("secret") 
-                    + "@" + properties.getProperty("clusterHostname", "cluster0.h7jzx3i.mongodb.net") 
-                    + "/?retryWrites=true&w=1";
+                    + "@" + properties.getProperty("clusterHostname", "cluster0.h7jzx3i.mongodb.net");
+            if (properties.containsKey("defaultDatabase")) {
+                connectionString += "/" + properties.getProperty("defaultDatabase") 
+                        + "?authSource=admin&retryWrites=true&w=1";
+            } else {
+                connectionString += "/?retryWrites=true&w=1";
+            }
 
             ServerApi serverApi = ServerApi.builder()
                     .version(ServerApiVersion.V1)


### PR DESCRIPTION
In an upcoming release the Vantiq server will support transactions for storage managers. This change works with that feature to expose transactional support for MongoDB Atlas.

We keep a cache / map of Vantiq supplied transaction IDs to the associated client session. When requests declare they are part of a transaction, we use the transaction's session to issue the command to mongo. The Vantiq system guarantees that all requests for a given transaction arrive to the same storage manager / service connector instance (and therefore have the transaction<-->client session mapping).

We currently place the transaction client sessions in a cache. The entries will be evicted and their sessions closed after some period of inactivity (15 minutes). 

Closes #19 