### PR TITLE
enable configuration of mongodb connection parameters and start up options

### DIFF
--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/InstanceConfigUtils.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/InstanceConfigUtils.java
@@ -24,8 +24,15 @@ public class InstanceConfigUtils {
     public static final String CONFIG_WAS_PROGRAMMATIC = "configWasProgrammatic";
     public static final String SERVER_CONFIG_FILENAME = "config.properties";
     public static final String SERVER_SECRETS_FILENAME = "secrets.properties";
-    public static final String PORT_PROP_NAME = "port";
-    public static final String TCP_PROBE_PORT_NAME = "tcpProbePort";
+    public static final String PORT_PROP = "port";
+    public static final String WORKER_THREADS_PROP = "workerThreads";
+    public static final String CONNECT_THREADS_PROP = "connectionThreads";
+    public static final String TCP_PROBE_PORT_PROP = "tcpProbePort";
+    public static final String MONGO_DEFAULT_DB_PROP = "mongoDefaultDatabase";
+    public static final String MONGO_AUTH_SOURCE_PROP = "mongoAuthSource";
+    public static final String MONGO_CONN_PROTOCOL_PROP = "mongoConnectionProtocol";
+    public static final String MONGO_HOST_PROP = "mongoClusterHostSpec";
+    public static final String MONGO_SERVER_API_PROP = "mongoServerApi";
     public static final String SECRETS_DIR_PROP = "io.vantiq.secretsDir";
     public static final String CONFIG_DIR_PROP = "io.vantiq.configDir";
     public static final Integer DEFAULT_PORT = 8888;
@@ -130,8 +137,8 @@ public class InstanceConfigUtils {
      */
     public Integer obtainPrimaryPort() {
         int port = DEFAULT_PORT;
-        if (serverConfigProperties.getProperty(PORT_PROP_NAME) != null) {
-            port = Integer.parseInt(serverConfigProperties.getProperty(PORT_PROP_NAME));
+        if (serverConfigProperties.getProperty(PORT_PROP) != null) {
+            port = Integer.parseInt(serverConfigProperties.getProperty(PORT_PROP));
         }
         return port;
     }
@@ -142,7 +149,7 @@ public class InstanceConfigUtils {
         synchronized (this) {
             localServerConfigProps = serverConfigProperties;
         }
-        return localServerConfigProps.getProperty("defaultDatabase");
+        return localServerConfigProps.getProperty(MONGO_DEFAULT_DB_PROP);
     }
 
     /**
@@ -161,7 +168,7 @@ public class InstanceConfigUtils {
 
         if (localServerConfigProps != null) {
             // Grab the property and return result
-            String portString = localServerConfigProps.getProperty(TCP_PROBE_PORT_NAME);
+            String portString = localServerConfigProps.getProperty(TCP_PROBE_PORT_PROP);
             if (portString != null) {
                 return Integer.parseInt(portString);
             }

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -95,20 +95,13 @@ public class AtlasStorageMgr implements VantiqStorageManager {
         return connection.connect(config).flatMapPublisher(client -> {
             MongoDatabase adminDb = client.getDatabase("admin");
             AtomicLong start = new AtomicLong();
-            return Flowable.fromPublisher(adminDb.runCommand(new Document("ping", 1)))
-                    .doOnSubscribe(s -> start.set(System.currentTimeMillis()))
-                    .map(doc -> {
-                // depending on the server version: the result can be an Integer 1, and it can be a Double 1.0
-                if (doc.containsKey("ok")) {
-                    if (doc.get("ok") instanceof Integer && (Integer)doc.get("ok") != 1) {
-                        throw new Exception("Failed to ping MongoDB Atlas");
-                    } else if (doc.get("ok") instanceof Double && (Double)doc.get("ok") != 1.0) {
-                        throw new Exception("Failed to ping MongoDB Atlas");
-                    }
-                }
-                log.debug("Connected to MongoDB Atlas, ping time: {}ms", System.currentTimeMillis() - start.get());
-                return doc;
-            });
+            return Flowable.fromPublisher(adminDb.runCommand(new Document("ping", 1))).doOnSubscribe(s ->
+                start.set(System.currentTimeMillis())
+            ).doOnComplete(() ->
+                    log.debug("Connected to MongoDB, ping time: {}ms", System.currentTimeMillis() - start.get())
+            ).doOnError(t ->
+                    log.error("Failed to connect to MongoDB", t)
+            );
         }).ignoreElements();
     }
 

--- a/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
+++ b/mongodb-atlas/src/main/java/io/vantiq/atlasConnector/AtlasStorageMgr.java
@@ -98,8 +98,13 @@ public class AtlasStorageMgr implements VantiqStorageManager {
             return Flowable.fromPublisher(adminDb.runCommand(new Document("ping", 1)))
                     .doOnSubscribe(s -> start.set(System.currentTimeMillis()))
                     .map(doc -> {
-                if (doc.get("ok", 0) != 1) {
-                    throw new Exception("Failed to ping MongoDB Atlas");
+                // depending on the server version: the result can be an Integer 1, and it can be a Double 1.0
+                if (doc.containsKey("ok")) {
+                    if (doc.get("ok") instanceof Integer && (Integer)doc.get("ok") != 1) {
+                        throw new Exception("Failed to ping MongoDB Atlas");
+                    } else if (doc.get("ok") instanceof Double && (Double)doc.get("ok") != 1.0) {
+                        throw new Exception("Failed to ping MongoDB Atlas");
+                    }
                 }
                 log.debug("Connected to MongoDB Atlas, ping time: {}ms", System.currentTimeMillis() - start.get());
                 return doc;

--- a/mongodb-atlas/src/main/resources/config.properties
+++ b/mongodb-atlas/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 # MongoDB related configuration options
 
-# mongoDefaultDatabase = ars02
+mongoDefaultDatabase = cluster0
 # mongoConnectionProtocol = mongodb
 # mongoClusterHostSpec = localhost
 # mongoServerAPI = V1

--- a/mongodb-atlas/src/main/resources/config.properties
+++ b/mongodb-atlas/src/main/resources/config.properties
@@ -1,2 +1,13 @@
-defaultDatabase = cluster0
-port = 8888
+# MongoDB related configuration options
+
+# mongoDefaultDatabase = ars02
+# mongoConnectionProtocol = mongodb
+# mongoClusterHostSpec = localhost
+# mongoServerAPI = V1
+# mongoAuthSource = admin
+
+# Storage Manager / Service Connector related configuration options
+
+# port = 8888
+# connectionThreads = 1
+# workerThreads = 1

--- a/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
+++ b/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
@@ -133,7 +133,7 @@ public class TestAtlasConnector {
 
         val type = session.initializeTypeDefinition(createTypeDefinition("TestType"));
         // should get an empty map for type restrictions
-        assert type.get("storageName").equals("cluster0:TestType");
+        assert ((String)type.get("storageName")).endsWith(":TestType");
 
         var result = session.insert("cluster0:TestType", Map.of("name", "Bart Simpson", "address", "123 Main St", "amount", 100));
         // should get an empty map for type restrictions


### PR DESCRIPTION
Connector can work successfully with Atlas as well as non-cloud mongodb installations. The connection string varies depending on what you are connecting to. Make those variables configurable via config.properties.

At start up time the service connector will start threads to listen for websocket connections and threads to handle work. Allow the number of threads to be configurable.

Fixes #23