### PR TITLE
correctly handle thrown errors

### DIFF
--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
@@ -81,116 +81,119 @@ public class StorageManagerVerticle extends AbstractVerticle {
     private Flowable<?> dispatch(SvcConnSvrMessage msg) {
         log.debug("In dispatch dispatching the next request msg: {}", msg.procName);
         Flowable<?> result;
-        if (msg.procName != null) {
-            // procedure name is <package name>.<service name>.<procedure name>
-            String[] parts = msg.procName.split("\\.");
-            if (parts.length < 2) {
-                throw new IllegalArgumentException("unrecognized storage manager service procedure call: "
-                        + msg.procName);
-            }
-            String procName = parts[parts.length-1];
-            switch (procName) {
-                case "update":
-                    result = storageManager.update((String) msg.params.get("storageName"),
-                                    (Map<String, Object>) msg.params.get("storageManagerReference"),
-                                    (Map<String, Object>) msg.params.get("values"), (Map<String, Object>) msg.params.get("qual"),
-                                    (Map<String, Object>) msg.params.get("options"))
-                            .toFlowable();
-                    break;
-                case "insertMany":
-                    result = storageManager.insertMany((String) msg.params.get("storageName"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
-                            (List<Map<String, Object>>) msg.params.get("values"),
-                            (Map<String, Object>)msg.params.get("options"));
-                    break;
-                case "insert":
-                    result = storageManager.insert((String) msg.params.get("storageName"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
-                            (Map<String, Object>) msg.params.get("values"),
-                            (Map<String, Object>) msg.params.get("options")).toFlowable();
-                    break;
-                case "count":
-                    result = storageManager.count((String) msg.params.get("storageName"),
-                                    (Map<String, Object>) msg.params.get("storageManagerReference"),
-                                    (Map<String, Object>) msg.params.get("qual"), (Map<String, Object>) msg.params.get("options"))
-                            .toFlowable();
-                    break;
-                case "select":
-                    result = storageManager.select((String) msg.params.get("storageName"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
-                            (Map<String, Object>) msg.params.get("properties"), (Map<String, Object>) msg.params.get("qual"),
-                            (Map<String, Object>) msg.params.get("options"));
-                    break;
-                case "aggregate":
-                    result = storageManager.aggregate((String) msg.params.get("storageName"),
-                            (Map<String, Object>) msg.params.get("storageManagerReference"),
-                            (List<Map<String, Object>>) msg.params.get("pipeline"),
-                            (Map<String, Object>) msg.params.get("options"));
-                    break;
-                case "selectOne":
-                    result = storageManager.selectOne((String) msg.params.get("storageName"),
-                                    (Map<String, Object>) msg.params.get("storageManagerReference"),
-                                    (Map<String, Object>) msg.params.get("properties"), (Map<String, Object>) msg.params.get("qual"),
-                                    (Map<String, Object>) msg.params.get("options"))
-                            .toFlowable();
-                    break;
-                case "delete":
-                    result = storageManager.delete((String) msg.params.get("storageName"),
-                                    (Map<String, Object>) msg.params.get("storageManagerReference"),
-                                    (Map<String, Object>) msg.params.get("qual"), (Map<String, Object>) msg.params.get("options"))
-                            .toFlowable();
-                    break;
-                case "getTypeRestrictions":
-                    result = storageManager.getTypeRestrictions().toFlowable();
-                    break;
-                case "initializeTypeDefinition":
-                    if (msg.params == null || !(msg.params.get("proposedType") instanceof Map)) {
-                        result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +
-                                msg.procName));
-                    } else {
-                        //noinspection unchecked
-                        result = storageManager.initializeTypeDefinition(
-                                (Map<String, Object>) msg.params.get("proposedType"),
-                                (Map<String, Object>) msg.params.get("existingType")
+        try {
+            if (msg.procName != null) {
+                // procedure name is <package name>.<service name>.<procedure name>
+                String[] parts = msg.procName.split("\\.");
+                if (parts.length < 2) {
+                    throw new IllegalArgumentException("unrecognized storage manager service procedure call: "
+                            + msg.procName);
+                }
+                String procName = parts[parts.length - 1];
+                switch (procName) {
+                    case "update":
+                        result = storageManager.update((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("values"), (Map<String, Object>) msg.params.get("qual"),
+                                (Map<String, Object>) msg.params.get("options")).toFlowable();
+                        break;
+                    case "insertMany":
+                        result = storageManager.insertMany((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (List<Map<String, Object>>) msg.params.get("values"),
+                                (Map<String, Object>) msg.params.get("options"));
+                        break;
+                    case "insert":
+                        result = storageManager.insert((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("values"),
+                                (Map<String, Object>) msg.params.get("options")).toFlowable();
+                        break;
+                    case "count":
+                        result = storageManager.count((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("qual"), (Map<String, Object>) msg.params.get("options")
                         ).toFlowable();
-                    }
-                    break;
-                case "typeDefinitionDeleted":
-                    if (msg.params == null || !(msg.params.get("type") instanceof Map)) {
-                        result = Flowable.error(new Exception("invalid parameters for storage manager service procedure call: " +
-                                msg.procName));
-                    } else {
-                        //noinspection unchecked
-                        result = storageManager.typeDefinitionDeleted(
-                                (Map<String, Object>) msg.params.get("type"),
+                        break;
+                    case "select":
+                        result = storageManager.select((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("properties"), (Map<String, Object>) msg.params.get("qual"),
+                                (Map<String, Object>) msg.params.get("options"));
+                        break;
+                    case "aggregate":
+                        result = storageManager.aggregate((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (List<Map<String, Object>>) msg.params.get("pipeline"),
+                                (Map<String, Object>) msg.params.get("options"));
+                        break;
+                    case "selectOne":
+                        result = storageManager.selectOne((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("properties"), (Map<String, Object>) msg.params.get("qual"),
                                 (Map<String, Object>) msg.params.get("options")
                         ).toFlowable();
-                    }
-                    break;
-                case "startTransaction":
-                    result = storageManager.startTransaction(
-                            (String)msg.params.get("vantiqTransactionId"),
-                            (Map<String, Object>) msg.params.get("options")
-                    ).toFlowable();
-                    break;
-                case "commitTransaction":
-                    result = storageManager.commitTransaction(
-                            (String)msg.params.get("vantiqTransactionId"),
-                            (Map<String, Object>) msg.params.get("options")
-                    ).toFlowable();
-                    break;
-                case "abortTransaction":
-                    result = storageManager.abortTransaction(
-                            (String)msg.params.get("vantiqTransactionId"),
-                            (Map<String, Object>) msg.params.get("options")
-                    ).toFlowable();
-                    break;
-                default:
-                    result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +
-                            msg.procName));
+                        break;
+                    case "delete":
+                        result = storageManager.delete((String) msg.params.get("storageName"),
+                                (Map<String, Object>) msg.params.get("storageManagerReference"),
+                                (Map<String, Object>) msg.params.get("qual"), (Map<String, Object>) msg.params.get("options")
+                        ).toFlowable();
+                        break;
+                    case "getTypeRestrictions":
+                        result = storageManager.getTypeRestrictions().toFlowable();
+                        break;
+                    case "initializeTypeDefinition":
+                        if (msg.params == null || !(msg.params.get("proposedType") instanceof Map)) {
+                            result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +
+                                    msg.procName));
+                        } else {
+                            //noinspection unchecked
+                            result = storageManager.initializeTypeDefinition(
+                                    (Map<String, Object>) msg.params.get("proposedType"),
+                                    (Map<String, Object>) msg.params.get("existingType")
+                            ).toFlowable();
+                        }
+                        break;
+                    case "typeDefinitionDeleted":
+                        if (msg.params == null || !(msg.params.get("type") instanceof Map)) {
+                            result = Flowable.error(new Exception("invalid parameters for storage manager service procedure call: " +
+                                    msg.procName));
+                        } else {
+                            //noinspection unchecked
+                            result = storageManager.typeDefinitionDeleted(
+                                    (Map<String, Object>) msg.params.get("type"),
+                                    (Map<String, Object>) msg.params.get("options")
+                            ).toFlowable();
+                        }
+                        break;
+                    case "startTransaction":
+                        result = storageManager.startTransaction(
+                                (String) msg.params.get("vantiqTransactionId"),
+                                (Map<String, Object>) msg.params.get("options")
+                        ).toFlowable();
+                        break;
+                    case "commitTransaction":
+                        result = storageManager.commitTransaction(
+                                (String) msg.params.get("vantiqTransactionId"),
+                                (Map<String, Object>) msg.params.get("options")
+                        ).toFlowable();
+                        break;
+                    case "abortTransaction":
+                        result = storageManager.abortTransaction(
+                                (String) msg.params.get("vantiqTransactionId"),
+                                (Map<String, Object>) msg.params.get("options")
+                        ).toFlowable();
+                        break;
+                    default:
+                        result = Flowable.error(new Exception("unrecognized storage manager service procedure call: " +
+                                msg.procName));
+                }
+            } else {
+                result = Flowable.error(new Exception("no procedure name given in service procedure call"));
             }
-        } else {
-            result = Flowable.error(new Exception("no procedure name given in service procedure call"));
+        } catch (Throwable t) {
+            result = Flowable.error(t);
         }
         return result;
     }

--- a/mongodb-atlas/src/main/resources/config.properties
+++ b/mongodb-atlas/src/main/resources/config.properties
@@ -2,7 +2,7 @@
 
 mongoDefaultDatabase = cluster0
 # mongoConnectionProtocol = mongodb
-# mongoClusterHostSpec = localhost
+# mongoClusterHostSpec = pleiades.9cgdu4v.mongodb.net
 # mongoServerAPI = V1
 # mongoAuthSource = admin
 

--- a/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
+++ b/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * run through some basic atlas connector tests
@@ -121,6 +122,21 @@ public class TestAtlasConnector {
     }
     
     @SuppressWarnings("unused")
+    @Test
+    void testErrors() {
+        AtomicBoolean gotError = new AtomicBoolean(false);
+        session.setErrorHandler(t -> {
+            if (t.getMessage().contains("unrecognized storage manager service procedure call: noSuchProcedure")) {
+                log.debug("expected error: {}", t.getMessage());
+                gotError.set(true);
+            } else {
+                fail("Unexpected error encountered in test", t);
+            }
+        });
+        session.noSuchProcedure();
+        assert gotError.get();
+    }
+    
     @Test
     void testInvocations() {
         val restricts = session.getTypeRestrictions();


### PR DESCRIPTION
Any throw went unhandled until the vert.x layer which meant no response was sent back over our socket connection

Fixes #27 