### PR TITLE
Allow specifying procedures to be system-only

### DIFF
--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
@@ -91,8 +91,11 @@ public class StorageManagerVerticle extends AbstractVerticle {
                 }
                 String procName = parts[parts.length - 1];
                 
-                // Pre 1.40 the value may be null
-                if ((msg.isSystemRequest == null || !msg.isSystemRequest) && storageManager.checkRequiresSystem(msg)) {
+                // In the future, it should be set by an explicit value isSystemRequest. For compatibility reasons, we
+                // must accept appending "__system" to the requestId as equivalent
+                boolean isSystemRequest = (msg.isSystemRequest != null && msg.isSystemRequest) ||
+                        (msg.requestId != null && msg.requestId.endsWith("__system"));
+                if (!isSystemRequest && storageManager.checkRequiresSystem(msg)) {
                     throw new IllegalArgumentException("Cannot run the procedure " + procName +
                             " from non-system namespaces.");
                 }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
@@ -90,6 +90,12 @@ public class StorageManagerVerticle extends AbstractVerticle {
                             + msg.procName);
                 }
                 String procName = parts[parts.length - 1];
+                
+                // Pre 1.40 the value may be null
+                if ((msg.isSystemRequest == null || !msg.isSystemRequest) && !storageManager.checkRequiresSystem(msg)) {
+                    throw new IllegalArgumentException("Cannot run ");
+                }
+                
                 switch (procName) {
                     case "update":
                         result = storageManager.update((String) msg.params.get("storageName"),

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
@@ -1,6 +1,5 @@
 package io.vantiq.svcconnector;
 
-import com.google.common.collect.Lists;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.disposables.Disposable;

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/StorageManagerVerticle.java
@@ -1,5 +1,6 @@
 package io.vantiq.svcconnector;
 
+import com.google.common.collect.Lists;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -92,8 +93,9 @@ public class StorageManagerVerticle extends AbstractVerticle {
                 String procName = parts[parts.length - 1];
                 
                 // Pre 1.40 the value may be null
-                if ((msg.isSystemRequest == null || !msg.isSystemRequest) && !storageManager.checkRequiresSystem(msg)) {
-                    throw new IllegalArgumentException("Cannot run ");
+                if ((msg.isSystemRequest == null || !msg.isSystemRequest) && storageManager.checkRequiresSystem(msg)) {
+                    throw new IllegalArgumentException("Cannot run the procedure " + procName +
+                            " from non-system namespaces.");
                 }
                 
                 switch (procName) {

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/SvcConnSvrMessage.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/SvcConnSvrMessage.java
@@ -1,5 +1,7 @@
 package io.vantiq.svcconnector;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.Map;
 
 /**
@@ -9,6 +11,7 @@ import java.util.Map;
  * <p>
  * All rights reserved.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SvcConnSvrMessage {
   public static final String WS_PING = "ping";
   public static final String WS_PONG = "pong";
@@ -16,4 +19,5 @@ public class SvcConnSvrMessage {
   public String requestId;
   public String procName;
   public Map<String, Object> params;
+  public Boolean isSystemRequest;
 }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
@@ -22,7 +22,14 @@ public interface VantiqStorageManager {
      * do anything necessary prior to receiving storage manager related requests
      */
     Completable initialize(Vertx vertx);
-
+    
+    /**
+     * Whether the message should only be accepted if it comes from the system namespace. If this returns true and the
+     * message is not from the system namespace, an error will be thrown.
+     *
+     * @param msg
+     * @return
+     */
     default boolean checkRequiresSystem(SvcConnSvrMessage msg) {
         return false;
     }

--- a/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
+++ b/java-rx-smgrsdk/src/main/java/io/vantiq/svcconnector/VantiqStorageManager.java
@@ -23,6 +23,10 @@ public interface VantiqStorageManager {
      */
     Completable initialize(Vertx vertx);
 
+    default boolean checkRequiresSystem(SvcConnSvrMessage msg) {
+        return false;
+    }
+    
     /**
      * What is and is not supported for types managed by this storage manager
      *

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/TestMainVerticle.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/TestMainVerticle.java
@@ -2,17 +2,14 @@ package io.vantiq.svcconnector;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-import groovy.lang.Tuple2;
 import io.vantiq.utils.SocketSession;
 import io.vantiq.utils.StorageManagerError;
 import io.vantiq.utils.StorageManagerErrorCodec;
 import io.vantiq.utils.SvcConnSvcMsgCodec;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.WebSocket;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -22,10 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -165,17 +159,5 @@ public class TestMainVerticle {
         gotError.set(false);
         session.count("", Collections.emptyMap(), null);
         assert gotError.get();
-    }
-    
-    public void writeBuffer(WebSocket ws, String jsonParams, VertxTestContext tc) {
-        try {
-            ws.write(Buffer.buffer(jsonParams), writeAr -> {
-                if (writeAr.failed()) {
-                    tc.failNow(writeAr.cause());
-                }
-            });
-        } catch (Throwable t) {
-            tc.failNow(t);
-        }
     }
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/TestMainVerticle.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/svcconnector/TestMainVerticle.java
@@ -1,16 +1,32 @@
 package io.vantiq.svcconnector;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import groovy.lang.Tuple2;
+import io.vantiq.utils.SocketSession;
+import io.vantiq.utils.StorageManagerError;
+import io.vantiq.utils.StorageManagerErrorCodec;
+import io.vantiq.utils.SvcConnSvcMsgCodec;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 /**
@@ -25,21 +41,45 @@ public class TestMainVerticle {
     /*
      * Deploy a single instance of the request processing verticle for Mongodb Atlas
      */
-    @BeforeEach
-    void deployVerticle(Vertx vertx, VertxTestContext testContext) {
+    @BeforeAll
+    static void deployVerticle(Vertx vertx, VertxTestContext testContext) {
         JsonObject verticleConfig = new JsonObject().put("storageManagerClassName",
-                "io.vantiq.svcconnector.NoopStorageManager");
+                "io.vantiq.utils.NoopStorageManager");
         DeploymentOptions deployOptions = new DeploymentOptions()
                 .setInstances(1)
                 .setConfig(verticleConfig);
         Supplier<Verticle> verticleSupplier = WebSocketRequestVerticle::new;
+        vertx.eventBus().registerDefaultCodec(StorageManagerError.class, new StorageManagerErrorCodec());
+        vertx.eventBus().registerDefaultCodec(SvcConnSvrMessage.class, new SvcConnSvcMsgCodec());
         vertx.deployVerticle(verticleSupplier, deployOptions, ar -> {
             if (ar.succeeded()) {
-                testContext.completeNow();
+                vertx.deployVerticle(StorageManagerVerticle::new, deployOptions, ar2 -> {
+                    if (!ar2.succeeded()) {
+                        testContext.failNow(ar2.cause());
+                    }
+                    testContext.completeNow();
+                });
             } else {
                 testContext.failNow(ar.cause());
             }
         });
+    }
+    
+    private SocketSession session;
+    @BeforeEach
+    void setup(Vertx vertx, VertxTestContext vtc) {
+        session = new SocketSession(t -> {
+            vtc.failNow(t);
+            fail("Unexpected error encountered in test", t);
+        });
+        session.connect(vertx);
+        vtc.completeNow();
+    }
+    
+    @AfterEach
+    void cleanup() {
+        // close the session
+        session.disconnect();
     }
 
     /*
@@ -97,5 +137,45 @@ public class TestMainVerticle {
                 testContext.failNow(ar.cause());
             }
         });
+    }
+    
+    @Test
+    void testsystemOnlyRestrictions() {
+        // Count is set up so it's only legal from the system namespace. Check that it works there
+        int count = session.count("", Collections.emptyMap(), true);
+        assert count == 0;
+        
+        // When messages are not from the system namespace, it should error. Set up the handler for the errors.
+        String expectedError = "Cannot run the procedure count from non-system namespaces.";
+        AtomicBoolean gotError = new AtomicBoolean(false);
+        session.setErrorHandler(ex -> {
+            String message = ex.getMessage();
+            if (message.equals(expectedError)) {
+                gotError.set(true);
+            } else {
+                fail("Unexpected error running from non-system namespace", ex);
+            }
+        });
+        
+        // Check that it fails when explicitly not the system namespace
+        session.count("", Collections.emptyMap(), false);
+        assert gotError.get();
+        
+        // Reset the error checker and make sure it fails implicitly not the system namespace
+        gotError.set(false);
+        session.count("", Collections.emptyMap(), null);
+        assert gotError.get();
+    }
+    
+    public void writeBuffer(WebSocket ws, String jsonParams, VertxTestContext tc) {
+        try {
+            ws.write(Buffer.buffer(jsonParams), writeAr -> {
+                if (writeAr.failed()) {
+                    tc.failNow(writeAr.cause());
+                }
+            });
+        } catch (Throwable t) {
+            tc.failNow(t);
+        }
     }
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/utils/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/utils/NoopStorageManager.java
@@ -110,6 +110,6 @@ public class NoopStorageManager implements VantiqStorageManager {
     
     @Override
     public boolean checkRequiresSystem(SvcConnSvrMessage msg) {
-        return msg.procName.endsWith("count") || msg.procName.endsWith("commitTransaction");
+        return msg.procName.endsWith("count");
     }
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/utils/NoopStorageManager.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/utils/NoopStorageManager.java
@@ -4,6 +4,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import io.vantiq.svcconnector.SvcConnSvrMessage;
 import io.vantiq.svcconnector.VantiqStorageManager;
 import io.vertx.rxjava3.core.Vertx;
 
@@ -105,5 +106,10 @@ public class NoopStorageManager implements VantiqStorageManager {
     @Override
     public Completable abortTransaction(String vantiqTransactionId, Map<String, Object> options) {
         return Completable.complete();
+    }
+    
+    @Override
+    public boolean checkRequiresSystem(SvcConnSvrMessage msg) {
+        return msg.procName.endsWith("count") || msg.procName.endsWith("commitTransaction");
     }
 }

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/utils/SocketSession.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/utils/SocketSession.java
@@ -27,7 +27,9 @@ import java.util.function.Consumer;
  * On connect we establish a websocket connection using the default port. Once established the Storage Manager API-like
  * calls can be made. Every entry point is synchronous.
  * <p/>
- * Copyright (c) 2023 Vantiq, Inc.
+ * A limited copy of the SocketSession in the MongoDB Atlas manager's tests.
+ * <p/>
+ * Copyright (c) 2024 Vantiq, Inc.
  * <p/>
  * All rights reserved.
  */
@@ -148,14 +150,6 @@ public class SocketSession {
         if (error.get() != null) {
             errorHandler.accept(error.get());
         }
-    }
-
-    public Map<String, Object> getTypeRestrictions() {
-        AtomicReference<Map<String, Object>> restrs = new AtomicReference<>();
-        writeAndHandle("com.pkg.myService.getTypeRestrictions", null, null, json ->
-                restrs.set(json.getJsonObject("result").getMap())
-        );
-        return restrs.get();
     }
     
     public int count(String storageName, Map<String, Map<String, String>> qual, Boolean isSystemNamespace) {

--- a/java-rx-smgrsdk/src/test/java/io/vantiq/utils/SocketSession.java
+++ b/java-rx-smgrsdk/src/test/java/io/vantiq/utils/SocketSession.java
@@ -1,0 +1,168 @@
+package io.vantiq.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vantiq.svcconnector.SvcConnSvrMessage;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Put together the basic operations for interacting with the storage manager over a websocket.<p/>
+ * 
+ * On connect we establish a websocket connection using the default port. Once established the Storage Manager API-like
+ * calls can be made. Every entry point is synchronous.
+ * <p/>
+ * Copyright (c) 2023 Vantiq, Inc.
+ * <p/>
+ * All rights reserved.
+ */
+@Slf4j
+public class SocketSession {
+    private final static ObjectMapper mapper = DatabindCodec.mapper();
+    WebSocket websocket;
+    @Setter
+    Consumer<Throwable> errorHandler;
+    
+    public SocketSession(Consumer<Throwable> errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+    
+    public void connect(Vertx vertx) {
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        val sync = new CountDownLatch(1);
+        
+        vertx.createHttpClient().webSocket(8888, "localhost", "/wsock/websocket", ar -> {
+            if (ar.succeeded()) {
+                // save the websocket for later use
+                websocket = ar.result();
+
+                // try / handle ping message to make sure we're connected
+                websocket.handler(buffer -> {
+                    // got response to ping (hopefully, its a pong)
+                    log.debug("received message from server: " + buffer);
+                    if (!buffer.toString().equals("pong")) {
+                        errorRef.set(new Throwable("unexpected response from server: " + buffer));
+                    }
+                    sync.countDown();
+                });
+
+                websocket.write(Buffer.buffer("ping"), writeAr -> {
+                    if (writeAr.failed()) {
+                        // could not write to the websocket, set the error and proceed
+                        errorRef.set(writeAr.cause());
+                        sync.countDown();
+                    }
+                });
+            } else {
+                // could not create the websocket, set the error and proceed
+                errorRef.set(ar.cause());
+                sync.countDown();
+            }
+        });
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            sync.await(15, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            errorRef.set(e);
+        }
+        if (errorRef.get() != null) {
+            errorHandler.accept(errorRef.get());
+        }
+    }
+    
+    public void disconnect() {
+        if (websocket != null) {
+            websocket.close();
+            websocket = null;
+        }
+    }
+    
+    private void writeAndHandle(String procName, Map<String, Object> params, Boolean isSystemRequest,
+                                Consumer<JsonObject> handler) {
+        SvcConnSvrMessage message = new SvcConnSvrMessage();
+        if (params != null && !params.containsKey("options")) {
+            // add an empty options map, watch out for immutable params args
+            params = new HashMap<>(params);
+            params.put("options", new HashMap<>());
+        }
+        message.params = params;
+        message.procName = procName;
+        message.requestId = UUID.randomUUID().toString();
+        if (isSystemRequest != null) {
+            message.isSystemRequest = isSystemRequest;
+        }
+
+        // make the call synchronous
+        final CountDownLatch sync = new CountDownLatch(1);
+
+        AtomicReference<RuntimeException> error = new AtomicReference<>();
+        // actually set up the handler first
+        websocket.handler(buffer -> {
+            JsonObject result = (JsonObject)buffer.toJson();
+            if (result.getString("errorMsg") != null) {
+                error.set(new RuntimeException(result.getString("errorMsg")));
+            }
+            // will get two (or more) results, one for the procedure call and one for the EOF -- ignore the latter
+            if (result.getBoolean("isEOF")) {
+                sync.countDown();
+                return;
+            }
+            if (handler != null) {
+                handler.accept(result);
+            }
+        });
+
+        // send a fully qualified procedure invocation
+        try {
+            websocket.write(Buffer.buffer(mapper.writeValueAsBytes(message)), ar -> {
+                if (ar.failed()) {
+                    errorHandler.accept(ar.cause());
+                }
+            });
+        } catch (JsonProcessingException e) {
+            errorHandler.accept(e);
+            return;
+        }
+
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            sync.await(15, TimeUnit.SECONDS);
+        } catch (InterruptedException ie) {
+            error.set(new RuntimeException(ie));
+        }
+        if (error.get() != null) {
+            errorHandler.accept(error.get());
+        }
+    }
+
+    public Map<String, Object> getTypeRestrictions() {
+        AtomicReference<Map<String, Object>> restrs = new AtomicReference<>();
+        writeAndHandle("com.pkg.myService.getTypeRestrictions", null, null, json ->
+                restrs.set(json.getJsonObject("result").getMap())
+        );
+        return restrs.get();
+    }
+    
+    public int count(String storageName, Map<String, Map<String, String>> qual, Boolean isSystemNamespace) {
+        AtomicInteger count = new AtomicInteger();
+        String procName = "com.pkg.myService.count";
+        writeAndHandle(procName, Map.of("storageManagerReference", Map.of(), "storageName", storageName, "qual", qual),
+                isSystemNamespace, json -> count.set(json.getInteger("result")));
+        return count.get();
+    }
+}

--- a/mongodb-atlas/src/main/resources/config.properties
+++ b/mongodb-atlas/src/main/resources/config.properties
@@ -11,3 +11,5 @@ mongoDefaultDatabase = cluster0
 # port = 8888
 # connectionThreads = 1
 # workerThreads = 1
+mongoClusterHostSpec=test2.xfu7cdb.mongodb.net
+port = 8888

--- a/mongodb-atlas/src/main/resources/config.properties
+++ b/mongodb-atlas/src/main/resources/config.properties
@@ -11,5 +11,3 @@ mongoDefaultDatabase = cluster0
 # port = 8888
 # connectionThreads = 1
 # workerThreads = 1
-mongoClusterHostSpec=test2.xfu7cdb.mongodb.net
-port = 8888

--- a/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
+++ b/mongodb-atlas/src/test/java/io/vantiq/atlasConnector/TestAtlasConnector.java
@@ -70,7 +70,7 @@ public class TestAtlasConnector {
             }
             vertx.deployVerticle(StorageManagerVerticle::new, deployOptions, ar2 -> {
                 if (!ar2.succeeded()) {
-                    testContext.failNow(ar.cause());
+                    testContext.failNow(ar2.cause());
                 }
                 testContext.completeNow();
             });

--- a/pythonsdk/src/main/python/vantiqservicesdk.py
+++ b/pythonsdk/src/main/python/vantiqservicesdk.py
@@ -178,7 +178,10 @@ class BaseVantiqServiceConnector:
             # Get the procedure name and parameters
             procedure_name = request.get("procName")
             params = request.get("params")
-            is_system_request = request.get("isSystemRequest", False)
+
+            # In the future, it should be set by an explicit value isSystemRequest. For compatibility reasons, we
+            # must accept appending "__system" to the requestId as equivalent
+            is_system_request = request.get("isSystemRequest", False) or request.get("requestId").endswith("__system")
 
             # Invoke the procedure and store the result
             request_timer = self.__get_resource_metric(self._resources_executions, procedure_name)

--- a/pythonsdk/src/main/python/vantiqservicesdk.py
+++ b/pythonsdk/src/main/python/vantiqservicesdk.py
@@ -178,12 +178,12 @@ class BaseVantiqServiceConnector:
             # Get the procedure name and parameters
             procedure_name = request.get("procName")
             params = request.get("params")
-            isSystemNs = request.get("isSystemRequest", False)
+            is_system_request = request.get("isSystemRequest", False)
 
             # Invoke the procedure and store the result
             request_timer = self.__get_resource_metric(self._resources_executions, procedure_name)
             with request_timer.time():
-                result = await self.__invoke(procedure_name, params, isSystemNs)
+                result = await self.__invoke(procedure_name, params, is_system_request)
                 if isinstance(result, AsyncIterator):
                     # Send back the results as they are received
                     async for data in result:

--- a/pythonsdk/src/main/python/vantiqservicesdk.py
+++ b/pythonsdk/src/main/python/vantiqservicesdk.py
@@ -250,8 +250,12 @@ class BaseVantiqServiceConnector:
         if not callable(func):
             raise Exception(f"Procedure {procedure_name} is not callable")
 
-        if not is_system_request and (self.__is_system_only(func) or self.check_system_required(procedure_name, params)):
-            raise Exception(f"Procedure {procedure_name} is only available to the system namespace")
+        if not is_system_request:
+            if self.__is_system_only(func):
+                raise Exception(f"Procedure {procedure_name} is only available to the system namespace")
+            elif self.check_system_required(procedure_name, params):
+                raise Exception(f"Procedure {procedure_name} is only available to the system namespace with the " +
+                                "parameters given")
 
         # Invoke the function (possibly using await)
         params = params or {}

--- a/pythonsdk/src/test/python/test_vantiqsevicessdk.py
+++ b/pythonsdk/src/test/python/test_vantiqsevicessdk.py
@@ -154,6 +154,13 @@ def test_invoke_system_only():
         assert response['errorMsg'] == ("Procedure conditionally_system_only_proc is only available to the system "
                                         "namespace with the parameters given")
         response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": True}, True)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['result'] == "Must be system NS? True"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
                                       {"system_required": False}, False)
         assert response['requestId'] == "123"
         assert response['isEOF']
@@ -165,13 +172,6 @@ def test_invoke_system_only():
         assert response['requestId'] == "123"
         assert response['isEOF']
         assert response['result'] == "Must be system NS? False"
-        response = client.get("/metrics")
-        assert response.status_code == 200
-        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
-                                      {"system_required": True}, True)
-        assert response['requestId'] == "123"
-        assert response['isEOF']
-        assert response['result'] == "Must be system NS? True"
         response = client.get("/metrics")
         assert response.status_code == 200
 

--- a/pythonsdk/src/test/python/test_vantiqsevicessdk.py
+++ b/pythonsdk/src/test/python/test_vantiqsevicessdk.py
@@ -129,6 +129,10 @@ def test_invoke_system_only():
         assert response['requestId'] == "123"
         assert response['isEOF']
         assert response['errorMsg'] == "Procedure system_only_proc is only available to the system namespace"
+        response = __invoke_procedure(websocket, "system_only_proc", "123", None, None)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['errorMsg'] == "Procedure system_only_proc is only available to the system namespace"
         response = __invoke_procedure(websocket, "system_only_proc", "123", None, True)
         assert response['requestId'] == "123"
         assert response['isEOF']
@@ -139,6 +143,12 @@ def test_invoke_system_only():
         # Test conditionally system-only procedure
         response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
                                       {"system_required": True}, False)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['errorMsg'] == ("Procedure conditionally_system_only_proc is only available to the system "
+                                        "namespace with the parameters given")
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": True}, None)
         assert response['requestId'] == "123"
         assert response['isEOF']
         assert response['errorMsg'] == ("Procedure conditionally_system_only_proc is only available to the system "

--- a/pythonsdk/src/test/python/test_vantiqsevicessdk.py
+++ b/pythonsdk/src/test/python/test_vantiqsevicessdk.py
@@ -140,6 +140,14 @@ def test_invoke_system_only():
         response = client.get("/metrics")
         assert response.status_code == 200
 
+        # Test with the "__system" syntax
+        response = __invoke_procedure(websocket, "system_only_proc", "123__system", None, None)
+        assert response['requestId'] == "123__system"
+        assert response['isEOF']
+        assert response['result'] == "This better be from the system namespace"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
         # Test conditionally system-only procedure
         response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
                                       {"system_required": True}, False)

--- a/pythonsdk/src/test/python/test_vantiqsevicessdk.py
+++ b/pythonsdk/src/test/python/test_vantiqsevicessdk.py
@@ -120,6 +120,52 @@ def test_invoke_errors():
         assert response['errorMsg'] == "Procedure service_name is not callable"
 
 
+def test_invoke_system_only():
+    with client.websocket_connect("/wsock/websocket") as websocket:
+        __handle_set_config(websocket)
+
+        # Test @system_only procedure
+        response = __invoke_procedure(websocket, "system_only_proc", "123", None, False)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['errorMsg'] == "Procedure system_only_proc is only available to the system namespace"
+        response = __invoke_procedure(websocket, "system_only_proc", "123", None, True)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['result'] == "This better be from the system namespace"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
+        # Test conditionally system-only procedure
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": True}, False)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['errorMsg'] == ("Procedure conditionally_system_only_proc is only available to the system "
+                                        "namespace with the parameters given")
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": False}, False)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['result'] == "Must be system NS? False"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": False}, True)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['result'] == "Must be system NS? False"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        response = __invoke_procedure(websocket, "conditionally_system_only_proc", "123",
+                                      {"system_required": True}, True)
+        assert response['requestId'] == "123"
+        assert response['isEOF']
+        assert response['result'] == "Must be system NS? True"
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
+
 def __handle_set_config(websocket, config=None):
     global config_set
     if config_set:
@@ -132,10 +178,12 @@ def __handle_set_config(websocket, config=None):
         config_set = True
 
 
-def __invoke_procedure(websocket, proc_name, request_id, params=None) -> dict:
+def __invoke_procedure(websocket, proc_name, request_id, params=None, from_system=None) -> dict:
     request = {"procName": proc_name, "requestId": request_id}
     if params is not None:
         request['params'] = params
+    if from_system is not None:
+        request['isSystemRequest'] = from_system
     websocket.send_json(request, 'binary')
     done = False
     result = None

--- a/pythonsdk/src/test/python/testservice.py
+++ b/pythonsdk/src/test/python/testservice.py
@@ -1,4 +1,5 @@
-from vantiqservicesdk import BaseVantiqServiceConnector, LoggerConfig
+from typing_extensions import override
+from vantiqservicesdk import BaseVantiqServiceConnector, LoggerConfig, system_only
 
 
 class TestServiceConnector(BaseVantiqServiceConnector):
@@ -21,6 +22,19 @@ class TestServiceConnector(BaseVantiqServiceConnector):
     async def test_asynciter_procedure(self):
         for i in range(0, 9):
             yield i
+
+    @system_only
+    async def system_only_proc(self):
+        return "This better be from the system namespace"
+
+    async def conditionally_system_only_proc(self, system_required):
+        return f"Must be system NS? {system_required}"
+
+    @override
+    def check_system_required(self, procedure_name: str, params: dict) -> bool:
+        if procedure_name == "conditionally_system_only_proc" and params.get("system_required", False):
+            return True
+        return False
 
     async def get_config(self):
         return await self._get_client_config()


### PR DESCRIPTION
Fixes #33

The server will provide an extra property specifying whether the message came from the system namespace. Python can do this with a decorator or a validation procedure. Java only has the latter, since AFAICT it's only for storage managers, and I don't foresee those having full procedures limited to the system NS.