### PR TITLE
Allow "client" to configure a maximum message size

### DIFF
--- a/pythonsdk/build.gradle
+++ b/pythonsdk/build.gradle
@@ -13,7 +13,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqServiceSdkVersion')) {
-        vantiqServiceSdkVersion = '0.0.11'
+        vantiqServiceSdkVersion = '0.0.12'
     }
     
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/pythonsdk/src/test/python/test_vantiqsevicessdk.py
+++ b/pythonsdk/src/test/python/test_vantiqsevicessdk.py
@@ -190,19 +190,22 @@ def test_message_size():
         config = {"maxMessageSize": max_size}
         __handle_set_config(websocket, config)
 
-        # Invoke procedure that returns a legal message size
-        size = int(max_size / 2)
-        response = __invoke_procedure(websocket, "echo_x", "123", {"size": size})
-        assert response['requestId'] == "123"
-        assert response['isEOF']
-        assert len(response['result']) == size
+        try:
+            # Invoke procedure that returns a legal message size
+            size = int(max_size / 2)
+            response = __invoke_procedure(websocket, "echo_x", "123", {"size": size})
+            assert response['requestId'] == "123"
+            assert response['isEOF']
+            assert len(response['result']) == size
 
-        # Invoke the procedure again with a larger response
-        size = max_size + 1
-        response = __invoke_procedure(websocket, "echo_x", "123", {"size": size})
-        assert response['requestId'] == "123"
-        assert response['isEOF']
-        assert response['errorMsg'] == "Message size 1045 exceeds maximum size 1000"
+            # Invoke the procedure again with a larger response
+            size = max_size + 1
+            response = __invoke_procedure(websocket, "echo_x", "123", {"size": size})
+            assert response['requestId'] == "123"
+            assert response['isEOF']
+            assert response['errorMsg'] == "Message size 1045 exceeds maximum size 1000"
+        finally:
+            __handle_clear_config(websocket)
 
 
 def test_default_message_size():
@@ -229,7 +232,6 @@ def test_key_error():
         assert response['errorMsg'] == "Failed to find expected dict key: 'key'"
 
 
-
 def __handle_set_config(websocket, config=None):
     global config_set
     if config_set:
@@ -241,6 +243,10 @@ def __handle_set_config(websocket, config=None):
         __invoke_procedure(websocket, SET_CLIENT_CONFIG_MSG, "1234", {"config": config})
         config_set = True
 
+def __handle_clear_config(websocket):
+    __invoke_procedure(websocket, CLEAR_CLIENT_CONFIG_MSG, "12345", {})
+    global config_set
+    config_set = False
 
 def __invoke_procedure(websocket, proc_name, request_id, params=None, from_system=None) -> dict:
     request = {"procName": proc_name, "requestId": request_id}

--- a/pythonsdk/src/test/python/testservice.py
+++ b/pythonsdk/src/test/python/testservice.py
@@ -42,5 +42,13 @@ class TestServiceConnector(BaseVantiqServiceConnector):
     def get_config_direct(self):
         return self._client_config
 
+    # noinspection PyMethodMayBeStatic
+    def echo_x(self, size: int):
+        return "x" * size
+
+    # noinspection PyMethodMayBeStatic
+    def key_error(self):
+        return {}["key"]
+
 
 app = TestServiceConnector().app


### PR DESCRIPTION
This let's the Vantiq server restrict the size of any response based on its configuration.

Also improve error message for "KeyError".

Fixes #35